### PR TITLE
Cleans up Add Stock screen and Stock tables on Daily Log

### DIFF
--- a/public/src/components/Manager/AddStock/AddStock.vue
+++ b/public/src/components/Manager/AddStock/AddStock.vue
@@ -24,7 +24,7 @@
           </v-container>
         </v-jumbotron>
 
-        <v-flex text-xs-center pt-4 pr-2 xs3>
+        <v-flex text-xs-center pt-4 pr-2 xs1>
           <v-text-field
             solo flat class="accent"
             autofocus
@@ -32,11 +32,43 @@
             type="number"
             v-model="formData.weight" />
         </v-flex>
+        <v-flex pt-4 pr-2 xs2>
+          <v-select
+            solo flat class="accent"
+            :items="[
+            'Compost',
+            'Plastics',
+            'Metals',
+            'Paper'
+            ]"
+            v-model="formData.type" label="Type" />
+        </v-flex>
         <v-flex pt-4 pr-2 xs3>
           <v-select
             solo flat class="accent"
-            :items="['Compost', 'Plastics', 'Metals', 'Paper']"
-            v-model="formData.type" label="Type" />
+            :items="[
+            'PET Clear',
+            'PET Colored',
+            'HDPE',
+            'PVC',
+            'LDPE',
+            'PP',
+            'PS',
+            'O',
+            'ABS',
+            'Cardboard',
+            'Newspaper',
+            'White paper',
+            'Magazine',
+            'Old book',
+            'Cement sack',
+            'Tetrapak',
+            'Aluminium can',
+            'Tin can',
+            'Scrap metal',
+            'Iron'
+            ]"
+            v-model="formData.subtype" label="Subtype" />
         </v-flex>
         <v-flex pt-4 xs3>
           <v-text-field
@@ -46,7 +78,8 @@
         </v-flex>
         <v-flex xs3 text-xs-right pt-4>
           <v-btn depressed color="primary"
-            @click.stop="save"
+            @click="save"
+            @click.stop="$router.go(-1)"
             :loading="savePending">Save
           </v-btn>
         </v-flex>
@@ -88,8 +121,6 @@ export default {
       addPending: false,
       fetchingDelivery: false,
       defaultFormData: {
-        weight: 20,
-        type: 'Compost',
         timestamp: new Date()
       }
     }
@@ -101,6 +132,8 @@ export default {
     } else {
       this.formData = this.defaultFormData
     }
+    const workers = this.$firestore.dailyCollections.workerhours
+    console.log(workers)
   },
   methods: {
     cancel () {

--- a/public/src/components/Manager/AddStock/EditStockForm.vue
+++ b/public/src/components/Manager/AddStock/EditStockForm.vue
@@ -4,11 +4,38 @@
       <v-container fluid grid-list-lg v-if="formData">
         <navigation-header />
         <v-layout row wrap>
-          <v-flex xs6>
+          <v-flex xs4>
             <v-text-field solo flat class="accent" label="Weight" suffix="kg" type="number" v-model="formData.weight" />
           </v-flex>
-          <v-flex xs6>
+          <v-flex xs4>
             <v-select solo flat class="accent" :items="['Compost', 'Plastics', 'Metals']" v-model="formData.type" label="Type" />
+          </v-flex>
+          <v-flex xs4>
+            <v-select
+              solo flat class="accent"
+              :items="[
+              'PET Clear',
+              'PET Colored',
+              'HDPE',
+              'PVC',
+              'LDPE',
+              'PP',
+              'PS',
+              'O',
+              'ABS',
+              'Cardboard',
+              'Newspaper',
+              'White paper',
+              'Magazine',
+              'Old book',
+              'Cement sack',
+              'Tetrapak',
+              'Aluminium can',
+              'Tin can',
+              'Scrap metal',
+              'Iron'
+              ]"
+              v-model="formData.subtype" label="Subtype" />
           </v-flex>
           <v-flex xs12>
             <v-text-field solo flat class="accent" label="Comments" v-model="formData.comments" auto-grow multi-line/>

--- a/public/src/components/Manager/AddStock/Table.vue
+++ b/public/src/components/Manager/AddStock/Table.vue
@@ -5,6 +5,7 @@
     :items="items"
     hide-actions class="elevation-1">
     <template slot="items" slot-scope="props">
+      <td>{{ props.item.subtype }}</td>
       <td>{{ props.item.weight }}</td>
       <td>{{ props.item.comments }}</td>
       <td class="text-xs-center">{{ $moment(props.item.timestamp).format('hh:mm A') }}</td>
@@ -16,7 +17,7 @@
     </template>
     <template slot="footer">
       <td colspan="100%">
-        <strong>{{ materialType }} Total Today: {{ totalWeight }}</strong>
+        <strong>{{ materialType }} Total Today: {{ totalWeight }} kg</strong>
       </td>
     </template>
   </v-data-table>
@@ -30,10 +31,10 @@ export default {
   },
   computed: {
     items () {
-      return this.$firestore.list.stock.filter(x => x.type === this.materialType)
+      return this.$firestore.dailyCollections.stock.filter(x => x.type === this.materialType)
     },
     totalWeight () {
-      return this.items.reduce((total, item) => total + parseInt(item.weight), 0)
+      return this.items.filter(x => x.type === this.materialType).reduce((total, item) => total + parseInt(item.weight), 0)
     }
   },
   data () {
@@ -41,7 +42,8 @@ export default {
       loading: false,
       timestamp: new Date(),
       headers: [
-        { text: 'Weight (kg)', align: 'center', sortable: true, value: 'weight' },
+        { text: 'Subtype', align: 'left', sortable: true, value: 'subtype' },
+        { text: 'Weight (kg)', align: 'left', sortable: true, value: 'weight' },
         { text: 'Comments', align: 'left', sortable: false, value: 'comments' },
         { text: 'Time', align: 'center', sortable: true, value: 'timestamp' },
         { text: 'Edit', align: 'center', sortable: false, value: null }

--- a/public/src/components/Manager/DailyLog/DailyLog.vue
+++ b/public/src/components/Manager/DailyLog/DailyLog.vue
@@ -11,8 +11,17 @@
       <log-header class="mt-4" action="/manager/material" :title="$t('headers.materialKg')" />
       <MaterialTable/>
 
-      <log-header class="mt-4" action="/manager/stock" title="Stock" />
-      <StockTable/>
+      <log-header class="mt-4" action="/manager/stock" title="Compost" />
+      <StockTable material-type="Compost" />
+
+      <log-header class="mt-4" action="/manager/stock" title="Plastics" />
+      <StockTable material-type="Plastics" />
+
+      <log-header class="mt-4" action="/manager/stock" title="Metals" />
+      <StockTable material-type="Metals" />
+
+      <log-header class="mt-4" action="/manager/stock" title="Paper" />
+      <StockTable material-type="Paper" />
 
       <log-header class="mt-4" action="/manager/worker-hours" :title="$t('headers.workerHours')" />
       <WorkerTimes/>

--- a/public/src/components/Manager/DailyLog/DailyLogStockTable.vue
+++ b/public/src/components/Manager/DailyLog/DailyLogStockTable.vue
@@ -2,44 +2,24 @@
   <v-data-table
     :loading="$firestore.collectionsPending.stock"
     :headers="headers"
-    :items="$firestore.list.stock"
-    hide-actions class="elevation-1"
-  >
-    <template slot="items" slot-scope="props" v-if="!collapsed" >
+    :items="items"
+    hide-actions class="elevation-1">
+    <template slot="items" slot-scope="props"  v-if="!collapsed">
+      <td>{{ props.item.subtype }}</td>
+      <td>{{ props.item.weight }}</td>
+      <td>{{ props.item.comments }}</td>
       <td class="text-xs-center">{{ $moment(props.item.timestamp).format('hh:mm A') }}</td>
-      <td class="text-xs-center">{{ props.item.worker.name }}</td>
-      <td class="text-xs-center">{{ props.item.inorganic }}</td>
-      <td class="text-xs-center">{{ props.item.organic }}</td>
       <td class="text-xs-center">
-        <template v-if="props.item.banjar">
-          {{ props.item.banjar.name }}
-        </template>
+        <v-btn icon @click="$router.push({ name: 'editStockForm', params: { id: props.item.id }})">
+          <v-icon size="17px" color="primary">fa-edit</v-icon>
+        </v-btn>
       </td>
     </template>
-    {{ materials }}
     <template slot="footer">
       <tr class="secondary pointer" @click.stop="collapsed = !collapsed">
-        <td class="text-xs-center">
-          <span class="body-2">
-            {{ materials.filter(x => x.type === 'Compost').reduce((total, item) => total + parseInt(item.weight || 0), 0) }}
-          </span>
+        <td colspan="100%">
+          <strong>{{ materialType }} Total Today: {{ totalWeight }} kg</strong>
         </td>
-        <td class="text-xs-center">
-          <span class="body-2">
-            {{ materials.filter(x => x.type === 'Plastics').reduce((total, item) => total + parseInt(item.weight || 0), 0) }}
-          </span>
-        </td>
-        <td class="text-xs-center">
-          <span class="body-2">
-            {{ materials.filter(x => x.type === 'Metals').reduce((total, item) => total + parseInt(item.weight || 0), 0) }}
-          </span>
-        </td>
-        <td class="text-xs-center">
-          <span class="body-2">
-            {{ materials.filter(x => x.type === 'Paper').reduce((total, item) => total + parseInt(item.weight || 0), 0) }}
-          </span>
-        </td>
-
       </tr>
     </template>
   </v-data-table>
@@ -48,28 +28,30 @@
 <script>
 
 export default {
+  props: {
+    materialType: { type: String, required: true }
+  },
+  computed: {
+    items () {
+      return this.$firestore.dailyCollections.stock.filter(x => x.type === this.materialType)
+    },
+    totalWeight () {
+      return this.items.filter(x => x.type === this.materialType).reduce((total, item) => total + parseInt(item.weight), 0)
+    }
+  },
   data () {
     return {
       collapsed: true,
       loading: false,
+      timestamp: new Date(),
       headers: [
-       { text: 'Compost', align: 'center', sortable: true, value: 'compost' },
-       { text: 'Plastics', align: 'center', sortable: true, value: 'plastics' },
-       { text: 'Metals', align: 'center', sortable: true, value: 'metal' },
-       { text: 'Paper', align: 'center', sortable: true, value: 'paper' }
+        { text: 'Subtype', align: 'left', sortable: true, value: 'subtype' },
+        { text: 'Weight (kg)', align: 'left', sortable: true, value: 'weight' },
+        { text: 'Comments', align: 'left', sortable: false, value: 'comments' },
+        { text: 'Time', align: 'center', sortable: true, value: 'timestamp' },
+        { text: 'Edit', align: 'center', sortable: false, value: null }
       ]
-    }
-  },
-  computed: {
-    materials () {
-      return this.$firestore.list.stock
     }
   }
 }
 </script>
-
-<style scoped>
-  .elevation-1 thead {
-    background: #e5ece9;
-  }
-</style>

--- a/public/yarn.lock
+++ b/public/yarn.lock
@@ -4385,6 +4385,10 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
+local-storage@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/local-storage/-/local-storage-1.4.2.tgz#7ec2d3fb7f1ea91a85b160d3a785058f87bfbfa5"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
Resolves GitHub issues:

- Add stock table needs to show "Type" column, #219
- Add stock type needs to list all the subtypes bug, #182
- Redirect after Add Stock bug, #169
- 24.0 Add Stock, #43 

Fixes Pull Request issues: 

- Release/add stock daily log view init, release, #216
- 24.0-Add Stock, cleanup, #212 

#216, #219, #182: Stock for the Daily Log has been split into four tables, one for each Stock type, in order to address the complication of Subtypes. The Stock Daily Logs expand and collapse accordingly and only show the relevant information for that calendar day.

#219, #182, #169, #43, #212: Add Stock Screen tables have been updated to show only information from that day, include Subtypes in the Stock submission form, and display the subtypes in the relevant tables. Users are now redirected back to the Daily Log screen after submitting a Stock. Subtype has also been added to the Edit Stock form so that subtypes can be edited after submission.


